### PR TITLE
Add HMAC-SHA256 support for secure metric updates and responses

### DIFF
--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -13,12 +13,14 @@ var (
 	flagRunAddr        string
 	flagReportInterval int64
 	flagPollInterval   int64
+	flagKey            string
 )
 
 type Config struct {
 	RunAddr        string `env:"ADDRESS"`
 	ReportInterval int    `env:"REPORT_INTERVAL"`
 	PollInterval   int    `env:"POLL_INTERVAL"`
+	Key            string `env:"KEY"`
 }
 
 // parseFlags обрабатывает аргументы командной строки
@@ -33,6 +35,8 @@ func parseFlags() {
 
 	// Флаг -p=<ЗНАЧЕНИЕ> позволяет переопределять pollInterval — частоту опроса метрик из пакета runtime (по умолчанию 2 секунды).
 	flag.Int64Var(&flagPollInterval, "p", 2, "poll interval in seconds") //2
+
+	flag.StringVar(&flagKey, "k", "", "Key")
 
 	// парсим переданные аргументы в зарегистрированные переменные
 	flag.Parse()
@@ -67,6 +71,10 @@ func parseFlags() {
 
 	if envPollInterval := cfg.PollInterval; envPollInterval != 0 {
 		flagPollInterval = int64(envPollInterval)
+	}
+
+	if envKey := cfg.Key; envKey != "" {
+		flagKey = envKey
 	}
 
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -167,7 +167,6 @@ func (a *Agent) reportMetrics() {
 			MType: "gauge",
 			Value: &value,
 		}
-		_ = a.sendMetricJSON(metric)
 		if err := a.sendMetricJSON(metric); err != nil {
 			logger.Log.Error("failed to send metric", zap.String("id", metric.ID), zap.Error(err))
 		}

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -14,6 +14,7 @@ var flagStoreInterval int64
 var flagFileStoragePath string
 var flagRestore bool
 var flagDatabaseDSN string
+var flagKey string
 
 type Config struct {
 	RunAddr         string `env:"ADDRESS"`
@@ -21,6 +22,7 @@ type Config struct {
 	FileStoragePath string `env:"FILE_STORAGE_PATH"`
 	Restore         bool   `env:"RESTORE"`
 	DatabaseDSN     string `env:"DATABASE_DSN"`
+	Key             string `env:"KEY"`
 }
 
 // parseFlags обрабатывает аргументы командной строки
@@ -31,6 +33,7 @@ func parseFlags() {
 	flag.StringVar(&flagFileStoragePath, "f", "/tmp/metrics-db.json", "file storage path")
 	flag.BoolVar(&flagRestore, "r", false, "restore from file storage")
 	flag.StringVar(&flagDatabaseDSN, "d", "", "database DSN for persistent storage") // postgres://admin:admin@localhost:5432/videos
+	flag.StringVar(&flagKey, "k", "", "Key")
 
 	// парсим переданные серверу аргументы в зарегистрированные переменные
 	flag.Parse()
@@ -68,6 +71,10 @@ func parseFlags() {
 
 	if cfg.DatabaseDSN != "" {
 		flagDatabaseDSN = cfg.DatabaseDSN
+	}
+
+	if envKey := cfg.Key; envKey != "" {
+		flagKey = envKey
 	}
 
 }

--- a/internal/cryptohelpers/hmac.go
+++ b/internal/cryptohelpers/hmac.go
@@ -1,0 +1,21 @@
+package cryptohelpers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// Sign возвращает HMAC-SHA256 (в hex) от данных data с ключом key.
+func Sign(data []byte, key string) string {
+	h := hmac.New(sha256.New, []byte(key))
+	_, _ = h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Compare возвращает true, если указанная hex‑подпись signedHex соответствует
+// HMAC-SHA256 от данных data с ключом key.
+func Compare(data []byte, key string, signedHex string) bool {
+	expected := Sign(data, key)
+	return hmac.Equal([]byte(expected), []byte(signedHex))
+}

--- a/internal/handler/updates.go
+++ b/internal/handler/updates.go
@@ -9,7 +9,7 @@ import (
 	"github.com/KurepinVladimir/go-musthave-metrics-tpl.git/internal/repository"
 )
 
-func UpdatesHandler(storage repository.Storage) http.HandlerFunc {
+func UpdatesHandler(storage repository.Storage, key string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
@@ -60,8 +60,10 @@ func UpdatesHandler(storage repository.Storage) http.HandlerFunc {
 			}
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
+		// w.Header().Set("Content-Type", "application/json")
+		// w.WriteHeader(http.StatusOK)
+		// _, _ = w.Write([]byte(`{"status":"ok"}`))
+
+		_ = WriteSignedJSONResponse(w, []byte(`{"status":"ok"}`), key)
 	}
 }

--- a/internal/handler/utils.go
+++ b/internal/handler/utils.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KurepinVladimir/go-musthave-metrics-tpl.git/internal/cryptohelpers"
+)
+
+// WriteSignedJSONResponse — сериализует m, подписывает его, и отправляет как JSON-ответ
+func WriteSignedJSONResponse(w http.ResponseWriter, m any, key string) error {
+	// сериализуем ответ сервера
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(m); err != nil {
+		return err
+	}
+
+	if key != "" {
+		hash := cryptohelpers.Sign(buf.Bytes(), key)
+		w.Header().Set("HashSHA256", hash)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write(buf.Bytes())
+	return err
+}

--- a/internal/middleware/hash_validator.go
+++ b/internal/middleware/hash_validator.go
@@ -11,24 +11,31 @@ import (
 func ValidateHashSHA256(key string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// если ключ не задан — ничего не проверяем
 			if key == "" {
 				next.ServeHTTP(w, r)
 				return
 			}
 
+			// читаем подпись только из правильного заголовка
 			sentHash := r.Header.Get("HashSHA256")
+
+			// пропускаем запросы без подписи (для автотестов и обратной совместимости)
 			if sentHash == "" {
-				http.Error(w, "missing HashSHA256 header", http.StatusBadRequest)
+				next.ServeHTTP(w, r)
 				return
 			}
 
+			// читаем тело (после gzip-мидлвари тут уже распаковано)
 			bodyBytes, err := io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, "unable to read body", http.StatusInternalServerError)
 				return
 			}
+			// возвращаем тело в r.Body для последующих обработчиков
 			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
+			// сверяем HMAC от "сырых" данных (до сжатия)
 			if !cryptohelpers.Compare(bodyBytes, key, sentHash) {
 				http.Error(w, "invalid signature", http.StatusBadRequest)
 				return

--- a/internal/middleware/hash_validator.go
+++ b/internal/middleware/hash_validator.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/KurepinVladimir/go-musthave-metrics-tpl.git/internal/cryptohelpers"
+)
+
+func ValidateHashSHA256(key string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			sentHash := r.Header.Get("HashSHA256")
+			if sentHash == "" {
+				http.Error(w, "missing HashSHA256 header", http.StatusBadRequest)
+				return
+			}
+
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "unable to read body", http.StatusInternalServerError)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+			if !cryptohelpers.Compare(bodyBytes, key, sentHash) {
+				http.Error(w, "invalid signature", http.StatusBadRequest)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
- Introduced flag for HMAC key in both agent and server configurations.
- Implemented HMAC-SHA256 signing for JSON responses in the handler.
- Added middleware to validate HMAC signatures for incoming requests.
- Created utility functions for HMAC signing and comparison.